### PR TITLE
add jlab extensions to base notebook

### DIFF
--- a/images/datahub-base-notebook/Dockerfile
+++ b/images/datahub-base-notebook/Dockerfile
@@ -62,4 +62,11 @@ RUN /usr/share/datahub/scripts/install-python-all.sh && \
     fix-permissions /home/$NB_USER && \
     chown -R jovyan:users /opt/conda/etc/jupyter/nbconfig && \
     chmod -R +r /opt/conda/etc/jupyter/nbconfig
+
+# Install jupyterlab extensions
+RUN jupyter labextension install @jupyterlab/fasta-extension  \
+@jupyterlab/katex-extension @jupyterlab/latex @jupyterlab/github \
+@jupyterlab/git @jupyterlab/pullrequests @jupyterlab/server-proxy \
+@jupyterlab/geojson-extension @jupyterlab/hdf5
+
 WORKDIR /home/jovyan


### PR DESCRIPTION
Not all jlab extensions work with current version of jupyterlab. The following are not included in this merge:
@jupyterlab/scheduler
@jupyterlab/apputils
@jupyterlab/translation
@jupyterlab/celltags
@jupyterlab/debugger
@jupyterlab/toc-extension
@jupyterlab/debugger-extension
@jupyterlab/translaton-extension
@jupyterlab/celltags-extension
@jupyterlab/google-drive