### PR TITLE
add missing comma in sed cmd

### DIFF
--- a/images/datahub-base-notebook/Dockerfile
+++ b/images/datahub-base-notebook/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update -y && \
     openssh-server \
     p7zip \
     apt-utils \
+    jq \
     p7zip-full && \
     apt-get clean && rm -rf /var/lib/apt/lists/* && \
     chmod g-s /usr/bin/screen && \

--- a/images/datahub-base-notebook/scripts/install-python/install-ipykernel_clean.sh
+++ b/images/datahub-base-notebook/scripts/install-python/install-ipykernel_clean.sh
@@ -6,5 +6,5 @@ ipython kernel install --name "python3_clean" \
                        --sys-prefix
 
 # Add to kernel config (set ENV PYTHONNOUSERSITE to 1)
-sed -i "s~\"python\"$~\"python\",\n \"env\": {\n  \"PYTHONNOUSERSITE\": \"1\"\n }~" \
+sed -i "s~\"python\",$~\"python\",\n \"env\": {\n  \"PYTHONNOUSERSITE\": \"1\"\n }~" \
        /opt/conda/share/jupyter/kernels/python3_clean/kernel.json

--- a/images/datahub-base-notebook/scripts/install-python/install-ipykernel_clean.sh
+++ b/images/datahub-base-notebook/scripts/install-python/install-ipykernel_clean.sh
@@ -6,5 +6,5 @@ ipython kernel install --name "python3_clean" \
                        --sys-prefix
 
 # Add to kernel config (set ENV PYTHONNOUSERSITE to 1)
-sed -i "s~\"python\",$~\"python\",\n \"env\": {\n  \"PYTHONNOUSERSITE\": \"1\"\n }~" \
-       /opt/conda/share/jupyter/kernels/python3_clean/kernel.json
+output=$(jq -s add /opt/conda/share/jupyter/kernels/python3_clean/kernel.json /usr/share/datahub/scripts/install-python/kernel_env.json)
+echo "$output" > /opt/conda/share/jupyter/kernels/python3_clean/kernel.json

--- a/images/datahub-base-notebook/scripts/install-python/kernel_env.json
+++ b/images/datahub-base-notebook/scripts/install-python/kernel_env.json
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "PYTHONNOUSERSITE": "1"
+    }
+}


### PR DESCRIPTION
@dtandersen @RockfordMankiniUCSD @Thomaswang0822 the python3 clean kernel.json is missing the required PYTHONNOUSERSITE:1 environment variable to ignore .local site-packages; this sed fix should re-add the envvar