### PR TITLE
Merge build cache usage into scipyml_buildtime branch

### DIFF
--- a/Documentation/images.md
+++ b/Documentation/images.md
@@ -82,7 +82,7 @@ In docker, cache can be loosely defined as "image layers that already exist in y
 
 When building images locally, Docker will automatically utilize the cached layers, because those layers are presented somewhere in the local storage. But this doesn't hold for Github Actions, because after each action run, our runtime environment will be deallocated and the next run will start from a new environment.
 
-There is a "local" solution, which is leveraging the [`Caches Management` provided by Github](https://github.com/ucsd-ets/datahub-docker-stack/actions/caches). The problem is cache stroage there is limited to 5GB and this is much lower than our need.
+There is a "local" solution, which is leveraging the [`Caches Management` provided by Github](https://github.com/ucsd-ets/datahub-docker-stack/actions/caches). The problem is cache storage there is limited to 5GB and this is much lower than our need.
 
 Another choice, or a workaround, is to use "remote" cache. This means we `docker pull` the image beforehand such that `docker build` can utilize the cache. This is less efficient than local cache, and may be worse than not using cache if download is slow. We use this approach, because the download bandwidth offered by Github is good and the time we spend on pulling/downloading is a lot shorter than no-cache build time.
 

--- a/Documentation/scripts.md
+++ b/Documentation/scripts.md
@@ -67,7 +67,8 @@ After `python3 main.py` is called from main.yml, it does a few things to ensure 
 
 ### 2. Core: [`build_and_test_containers()`](/scripts/runner.py#L130)
 
-- It logins to the Docker client with Github secrets **DOCKERHUB_TOKEN** and **DOCKERHUB_USER**. [`login()`](/scripts/docker_adapter.py#L86)
+- It logs into the Docker client of Python SDK with Github secrets **DOCKERHUB_TOKEN** and **DOCKERHUB_USER**. [`login()`](/scripts/docker_adapter.py#L86)
+- It also logs into the Docker daemon directly using `docker login` CLI. This enables the checking of existence of an image with a particular tag on Dockerhub, see [build cache explanation](/Documentation/images.md#image-build-cache) and [its implementation](/scripts/docker_adapter.py#L315) for more details.
 - It performs a BFS on the build-info tree and does the following to each Node if isn't marked skipped:
   - build: The corresponding Dockerfile at `images/<image_name>` is run to build an image. [`build()`](/scripts/docker_adapter.py#L31)
   - basic test: Image-specific tests in `images/<image_name>/tests/` and common tests (apply to all images) in `images/tests_common/` are executed within the Docker container. [`run_basic_test()`](/scripts/runner.py#L94)

--- a/images/rstudio-notebook/Dockerfile
+++ b/images/rstudio-notebook/Dockerfile
@@ -39,9 +39,8 @@ RUN ( echo 'LD_PRELOAD=/opt/k8s-support/lib/libnss_wrapper.so'; echo 'NSS_WRAPPE
 
 # The desktop package uses /usr/lib/rstudio/bin
 ENV PATH="${PATH}:/usr/lib/rstudio-server/bin" \
+    SHELL=/bin/bash \ 
     LD_LIBRARY_PATH="/usr/lib/R/lib:/lib:/usr/lib/x86_64-linux-gnu:/usr/lib/jvm/java-7-openjdk-amd64/jre/lib/amd64/server:/opt/conda/lib/R/lib"
-
-ENV SHELL=/bin/bash
 
 COPY ./lib /opt/k8s-support/lib
 

--- a/images/rstudio-notebook/Dockerfile
+++ b/images/rstudio-notebook/Dockerfile
@@ -54,3 +54,4 @@ COPY ./test ./integration_tests /home/jovyan/
 USER $NB_USER
 
 RUN conda init bash
+

--- a/images/rstudio-notebook/Dockerfile
+++ b/images/rstudio-notebook/Dockerfile
@@ -1,7 +1,5 @@
 ARG BASE_TAG=latest
 FROM ucsdets/datahub-base-notebook:${BASE_TAG}
-#$BASE_TAG
-#2021.3-31e0c4e
 
 USER root
 

--- a/images/rstudio-notebook/Dockerfile
+++ b/images/rstudio-notebook/Dockerfile
@@ -54,4 +54,3 @@ COPY ./test ./integration_tests /home/jovyan/
 USER $NB_USER
 
 RUN conda init bash
-

--- a/images/rstudio-notebook/Dockerfile
+++ b/images/rstudio-notebook/Dockerfile
@@ -7,8 +7,8 @@ USER root
 
 # Follow instructions atL https://www.rstudio.com/products/rstudio/download-server/
 ENV RSTUDIO_PKG=rstudio-server-1.4.1717-amd64.deb \
-    RSTUDIO_URL=https://download2.rstudio.org/server/bionic/amd64/${RSTUDIO_PKG} \
     RSESSION_PROXY_RSTUDIO_1_4=true
+ENV RSTUDIO_URL=https://download2.rstudio.org/server/bionic/amd64/${RSTUDIO_PKG}
 
 # rstudio installation expects R to live under /usr/bin, /bin/, etc.
 RUN ln -s /opt/conda/bin/R /usr/bin/R && \

--- a/images/scipy-ml-notebook/Dockerfile
+++ b/images/scipy-ml-notebook/Dockerfile
@@ -94,7 +94,7 @@ ENV PATH=${PATH}:/usr/local/nvidia/bin:/opt/conda/bin
 #sad issue with github ref
 
 
-# Does some CONDA/CUDA stuff
+# Do some CONDA/CUDA stuff
 # Copy libdevice file to the required path
 RUN mkdir -p $CONDA_DIR/lib/nvvm/libdevice && \
 	cp $CONDA_DIR/lib/libdevice.10.bc $CONDA_DIR/lib/nvvm/libdevice/

--- a/images/scipy-ml-notebook/run_jupyter.sh
+++ b/images/scipy-ml-notebook/run_jupyter.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
 jupyter notebook "$@"
-

--- a/scripts/docker_adapter.py
+++ b/scripts/docker_adapter.py
@@ -297,7 +297,15 @@ def prepull_tagging_images(orig_images: List[str]) -> bool:
 
 
 def on_Dockerhub(img: str, tag: str) -> bool:
-    command = ["docker", "manifest", "inspect", f"{img}:{tag}"]
+    """Check whether img:tag exist on the Dockerhub. 
+    Helper called by pull_build_cache()
+
+    Returns:
+        bool: exist or not
+    """
+    docker_config_dir = os.path.expanduser("~/.docker")  # Path to the Docker configuration directory
+
+    command = ["docker", "--config", docker_config_dir, "manifest", "inspect", f"{img}:{tag}"]
     result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # bash command returns 0 on success (found image), 1 on failure
     return result.returncode == 0
@@ -313,7 +321,7 @@ def pull_build_cache(node: Node) -> bool:
             which cache version (self or stable) to use;
 
     Returns:
-        bool: whether step 1 is successful. 
+        bool: whether self cache exists
     """
     full_name = node.full_image_name
     try:

--- a/scripts/docker_adapter.py
+++ b/scripts/docker_adapter.py
@@ -65,7 +65,7 @@ def build(node: Node) -> Tuple[bool, str]:
             nocache=False,
             decode=True,
             rm=False,
-            cache_from=[node.full_image_name]
+            cache_from=[node.full_image_name, node.stable_image_name]
         ):
             # line is of type dict
             content_str = line.get('stream', '').strip()    # sth like 'Step 1/20 : ARG PYTHON_VERSION=python-3.9.5'

--- a/scripts/docker_adapter.py
+++ b/scripts/docker_adapter.py
@@ -303,14 +303,14 @@ def on_Dockerhub(img: str, tag: str) -> bool:
     Returns:
         bool: exist or not
     """
-    docker_config_dir = os.path.expanduser("~/.docker")  # Path to the Docker configuration directory
 
-    command = ["docker", "--config", docker_config_dir, "manifest", "inspect", f"{img}:{tag}"]
-    result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    logger.error(f"{result.stdout.decode().strip()}")
-    logger.error(f"{result.stderr.decode().strip()}")
+    # command = ["docker", "manifest", "inspect", f"{img}:{tag}"]
+    command = f"docker manifest inspect {img}:{tag} > /dev/null"
+    # result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    exit_code = os.system(command)
     # bash command returns 0 on success (found image), 1 on failure
-    return result.returncode == 0
+    # return result.returncode == 0
+    return exit_code == 0
 
 def pull_build_cache(node: Node) -> bool:
     """Go to Dockerhub and attempt the following 2 things:

--- a/scripts/docker_adapter.py
+++ b/scripts/docker_adapter.py
@@ -307,6 +307,8 @@ def on_Dockerhub(img: str, tag: str) -> bool:
 
     command = ["docker", "--config", docker_config_dir, "manifest", "inspect", f"{img}:{tag}"]
     result = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    logger.error(f"{result.stdout.decode().strip()}")
+    logger.error(f"{result.stderr.decode().strip()}")
     # bash command returns 0 on success (found image), 1 on failure
     return result.returncode == 0
 

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -189,9 +189,6 @@ def build_and_test_containers(
                 })
                 q.append(child)
 
-            ## Can docker build go to Dockerhub and fetch existing image:tag for FROM (at Dockerfile first line)?
-            # node.rebuild = node.rebuild or (len(node.children) > 0 and not docker_adapter.image_tag_exists(node) )
-            # logger.info(f"### {node.image_name} rebuild after check? {node.rebuild}")  # TO REMOVE
             node_order.append(node)
 
     results = []        # no matter success or failure
@@ -199,10 +196,11 @@ def build_and_test_containers(
 
     # prepull images inorder to use cache
     # AND mark rebuild for those without cache yet
+    last_t = datetime.datetime.now()  # to log timestamp
     for i, node in enumerate(node_order):
         if not docker_adapter.pull_build_cache(node):
             # self doesn't exist on Dockerhub, rebuild
-            logger.info(f"{node.full_image_name} doesn't exist on Dockerhub. Will rebuild and save futre build time.")
+            logger.info(f"{node.full_image_name} doesn't exist on Dockerhub. Will rebuild and save future build time.")
             node_order[i].rebuild = True
     last_t, m, s = get_time_duration(last_t)
     logger.info(f"TIME: Prepull took {m} mins {s} secs")

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -171,7 +171,8 @@ def build_and_test_containers(
 
     docker_adapter.login(username, password)
     # try login also via CLI to check image existence on Dockerhub later
-    login_cmd = f"docker login -u {username} -p {password}"
+    # login_cmd = f"docker login -u {username} -p {password}"
+    login_cmd = f"echo $DOCKERHUB_TOKEN | docker login -u {username} --password-stdin"
     os.system(login_cmd)
 
     q = [root]

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -193,15 +193,20 @@ def build_and_test_containers(
             # pushing children to the queue
             # This ensures a branch-first build of parent NOT trigger
             # an unnecessary child rebuild
-            node.rebuild = node.rebuild or not docker_adapter.image_tag_exists(node)
-            logger.info(f"### {node.image_name} rebuild after check? {node.rebuild}")  # TO REMOVE
+
+            ## Can docker build go to Dockerhub and fetch existing image:tag for FROM (at Dockerfile first line)?
+            # node.rebuild = node.rebuild or (len(node.children) > 0 and not docker_adapter.image_tag_exists(node) )
+            # logger.info(f"### {node.image_name} rebuild after check? {node.rebuild}")  # TO REMOVE
             node_order.append(node)
 
     results = []        # no matter success or failure
     full_names = []     # a list of all-success image full names
 
     # prepull images inorder to use cache
+    last_t = datetime.datetime.now()  # to log timestamp
     docker_adapter.prepull_images([node.full_image_name for node in node_order], allow_failure=True)
+    last_t, m, s = get_time_duration(last_t)
+    logger.info(f"TIME: Prepull took {m} mins {s} secs")
     for node in node_order:
         last_t = datetime.datetime.now()  # to log timestamp
         try:

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -170,6 +170,9 @@ def build_and_test_containers(
     """
 
     docker_adapter.login(username, password)
+    # try login also via CLI to check image existence on Dockerhub later
+    login_cmd = f"docker login -u {username} -p {password}"
+    os.system(login_cmd)
 
     q = [root]
     node_order = []

--- a/scripts/runner.py
+++ b/scripts/runner.py
@@ -171,7 +171,6 @@ def build_and_test_containers(
 
     docker_adapter.login(username, password)
     # try login also via CLI to check image existence on Dockerhub later
-    # login_cmd = f"docker login -u {username} -p {password}"
     login_cmd = f"echo $DOCKERHUB_TOKEN | docker login -u {username} --password-stdin"
     os.system(login_cmd)
 

--- a/scripts/tagger.py
+++ b/scripts/tagger.py
@@ -57,7 +57,7 @@ def run_tagging(
         return True
 
     logger.info("prepulling images")
-    docker_adapter.prepull_images(orig_images=original_names)
+    docker_adapter.prepull_tagging_images(orig_images=original_names)
     logger.info("finished prepull")
 
     tagged = [] # each element is like 'ucsdets/datahub-base-notebook:2023.2-stable'

--- a/scripts/tree.py
+++ b/scripts/tree.py
@@ -29,6 +29,11 @@ class Node:
     def full_image_name(self):
         return self.image_name + ':' + self.image_tag
 
+    # TODO: temporary, should be removed later
+    @property
+    def stable_image_name(self):
+        return self.image_name + ':' + self.image_tag[:6] + '-stable' 
+
     def print_info(self):
         print( f"""image_name: {self.image_name},
                 git_suffix: {self.git_suffix}, 

--- a/tests/test_docker_adapter.py
+++ b/tests/test_docker_adapter.py
@@ -79,7 +79,7 @@ class TestDocker(unittest.TestCase):
         @patch('scripts.docker_adapter.__docker_client', images=mock_images, close=mock_close)
         def run_test(pos_arg):
             # NOTE: need pos_arg when we @patch with keyword-arg
-            return internal_docker.prepull_images(self.orig_images)
+            return internal_docker.prepull_tagging_images(self.orig_images)
 
         result = run_test()
         return (result, mock_pull, mock_close)


### PR DESCRIPTION
After the merge, we will deprecate test_build_cache and build_cache_v2 branches, which are mostly for experiment. 
scipyml_buildtime holds all our attempts to save build time, and will be merged to main in a different PR