### PR TITLE
Improve pip/conda cache cleanup

### DIFF
--- a/images/datascience-notebook/Dockerfile
+++ b/images/datascience-notebook/Dockerfile
@@ -76,15 +76,18 @@ ENV JUPYTERHUB_USER=${NB_USER}
 
 # Install jupyterlab extensions
 RUN pip install jupyterlab-github jupyterlab-latex jupyterlab-git \
-    jupyterlab-fasta jupyterlab-pullrequests jupyterlab-geojson
+    jupyterlab-fasta jupyterlab-pullrequests jupyterlab-geojson && \
+    pip cache purge
 
+ENV ENV 
 # Datascience packages
 RUN pip install dpkt \
     nose \
     datascience && \
     python -c 'import matplotlib.pyplot' && \
     fix-permissions $CONDA_DIR && \
-    fix-permissions /home/$NB_USER
+    fix-permissions /home/$NB_USER && \
+    pip cache purge
 
 RUN conda clean -tipsy
 

--- a/images/datascience-notebook/Dockerfile
+++ b/images/datascience-notebook/Dockerfile
@@ -79,7 +79,6 @@ RUN pip install jupyterlab-github jupyterlab-latex jupyterlab-git \
     jupyterlab-fasta jupyterlab-pullrequests jupyterlab-geojson && \
     pip cache purge
 
-ENV ENV 
 # Datascience packages
 RUN pip install dpkt \
     nose \

--- a/images/scipy-ml-notebook/Dockerfile
+++ b/images/scipy-ml-notebook/Dockerfile
@@ -38,11 +38,13 @@ RUN mamba install \
 	nccl \
 	-y && \
 	fix-permissions $CONDA_DIR && \
-	fix-permissions /home/$NB_USER
+	fix-permissions /home/$NB_USER && \
+    mamba clean -a -y
 
 RUN mamba install -c "nvidia/label/cuda-11.8.0" cuda-nvcc -y && \
 	fix-permissions $CONDA_DIR && \
-	fix-permissions /home/$NB_USER
+	fix-permissions /home/$NB_USER && \
+    mamba clean -a -y
 
 # install protobuf to avoid weird base type error. seems like if we don't then it'll be installed twice.
 # https://github.com/spesmilo/electrum/issues/7825
@@ -61,10 +63,11 @@ RUN pip install --no-cache-dir  datascience \
 	pycocotools \
 	pillow \
 	nvidia-cudnn-cu11==8.6.0.163 \
-	tensorflow==2.12.* && \
+    tensorflow==2.12.0 \
+    keras==2.12.0 && \
 	fix-permissions $CONDA_DIR && \
-	fix-permissions /home/$NB_USER
-
+	fix-permissions /home/$NB_USER && \
+    pip cache purge
 
 
 # Update these in spec.yml according to https://pytorch.org/get-started/locally/
@@ -74,7 +77,8 @@ ARG TORCH_VER="1.7.1+cu101" \
 
 # torch must be installed separately since it requires a non-pypi repo. See stable version above
 RUN pip install torch==${TORCH_VER} torchvision==${TORCH_VIS_VER} torchaudio==${TORCH_AUD_VER} \
-	-f https://download.pytorch.org/whl/torch_stable.html
+	-f https://download.pytorch.org/whl/torch_stable.html && \
+    pip cache purge
 
 # to use nvidia-smi command to check GPU & driver
 # RUN ln -s /usr/local/nvidia/bin/nvidia-smi /opt/conda/bin/nvidia-smi


### PR DESCRIPTION
**Lose 3.4GB _fast_ with this one simple trick!**  

Seriously, though - I noticed that scipy-ml:~jovyan/.cache had quite a bit of cruft, this PR adds "pip cache purge" and "{conda,mamba} clean --all -y" each time one of those tools is used to download.  ("--no-cache-dir" as specified in several places simply means the cache won't be consulted - doesn't inhibit creation.)

Image sizes for comparison:
ghcr.io/ucsd-ets/scipy-ml-notebook                      2023.2-fix-pip-conda-cleanup       2c7b646798d81       16.7GB
ghcr.io/ucsd-ets/scipy-ml-notebook                      2023.2-stable                      736f54814dd26       20.1GB
